### PR TITLE
FIx URL encoding

### DIFF
--- a/weborphans
+++ b/weborphans
@@ -181,7 +181,7 @@ class Spider:
             return
 
         # URL encode special characters like spaces:
-        urlpath = urllib.quote(urlparsed.path)
+        urlpath = urllib.quote(urlparsed.path.encode('utf-8'))
 
         # This check must come after the special char substitution.
         if urlpath in self.urls_succeeded or urlpath in self.urls_failed:


### PR DESCRIPTION
URL encoding (using quote method) fails if a unicode character is in the URL.
This seems to be because the string was using a different encoding, and it fixes the issue if I encode in utf-8 like this.